### PR TITLE
Add timeout on mute function

### DIFF
--- a/AudioDevice.py
+++ b/AudioDevice.py
@@ -1,4 +1,6 @@
 import time
+from wrapt_timeout_decorator import *
+
 
 
 class AudioDevice:
@@ -10,6 +12,8 @@ class AudioDevice:
         # not implemented
         pass
 
+    
+    @timeout(1)
     def mute(self, mute: bool):
         if mute:
             self.mute_on()

--- a/AudioSystem.py
+++ b/AudioSystem.py
@@ -4,9 +4,6 @@ class AudioSystem:
     
     def focus_device(self, device_name):
         for name, device in self.audio_devices.items():
-            if name == device_name:
-                device.mute_off()
-            else:
-                device.mute_on()
+            device.mute(name != device_name)
 
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyvizio
 asyncio
+wrapt_timeout_decorator


### PR DESCRIPTION
Before:
Mute command would hang on audio device when it's off.

After:
Add timeout on mute command so commands won't hang on device that is off.