### PR TITLE
Bug fix for indeterminate muting

### DIFF
--- a/src/AudioDevice.py
+++ b/src/AudioDevice.py
@@ -28,7 +28,8 @@ class AudioDevice:
 
     
     def mute_on(self):
-        if not self.already_muted():
+        already_muted = self.already_muted()
+        if not already_muted:
             self.send_mute_on_command()
 
     def send_mute_on_command(self):
@@ -44,7 +45,7 @@ class AudioDevice:
         pass
 
     def already_muted(self) -> bool:
-        self.send_already_muted_command()
+        return self.send_already_muted_command()
     
     def send_already_muted_command(self) -> bool:
         # not implemented

--- a/src/VizioTv.py
+++ b/src/VizioTv.py
@@ -9,7 +9,7 @@ class VizioTv(AudioDevice) :
         self.name = name
 
     def get_name(self) -> str:
-        return self.vizio_tv.name
+        return self.name
 
     def send_mute_on_command(self):
         asyncio.get_event_loop().run_until_complete(self.vizio_tv.mute_on())
@@ -18,7 +18,7 @@ class VizioTv(AudioDevice) :
         asyncio.get_event_loop().run_until_complete(self.vizio_tv.mute_off())
 
     def send_already_muted_command(self) -> bool:
-        asyncio.get_event_loop().run_until_complete(self.vizio_tv.is_muted())
+        return asyncio.get_event_loop().run_until_complete(self.vizio_tv.is_muted())
 
     def get_volume(self) -> int:
         asyncio.get_event_loop().run_until_complete(self.vizio_tv.get_current_volume())


### PR DESCRIPTION
Before:
None being returned caused commands to be sent to vizio tv's when not necessary

After:
Add explicit return to get mute status command to fix this